### PR TITLE
Improved error handling in processing step

### DIFF
--- a/anno-state-machine-processor/src/main/java/se/transientink/annostatemachine/processor/Model.java
+++ b/anno-state-machine-processor/src/main/java/se/transientink/annostatemachine/processor/Model.java
@@ -438,17 +438,17 @@ class Model {
                 for (ConnectionRef connectionRef : entry.getValue()) {
                     if (!mStates.contains(nameToStateMap.get(connectionRef.getFrom()))) {
                         isValid = false;
-                        messager.printMessage(Diagnostic.Kind.ERROR, errorTag + " - Unknown FROM state "
+                        messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING, errorTag + " - Unknown FROM state "
                                 + connectionRef.getFrom() + " used in connection " + connectionRef.getName() + ". Do you have a typo?");
                     }
                     if (!connectionRef.getTo().equals(ConnectionRef.WILDCARD) && !mStates.contains(nameToStateMap.get(connectionRef.getTo()))) {
                         isValid = false;
-                        messager.printMessage(Diagnostic.Kind.ERROR, errorTag + " - Unknown TO state "
+                        messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING, errorTag + " - Unknown TO state "
                                 + connectionRef.getTo() + " used in connection " + connectionRef.getName() + ". Do you have a typo?");
                     }
                     if (!mSignals.contains(new SignalRef(connectionRef.getSignal()))) {
                         isValid = false;
-                        messager.printMessage(Diagnostic.Kind.ERROR, errorTag + " - Unknown SIGNAL "
+                        messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING, errorTag + " - Unknown SIGNAL "
                                 + connectionRef.getSignal() + " used in connection " + connectionRef.getName() + ". Do you have a typo?");
                     }
                 }
@@ -458,7 +458,7 @@ class Model {
         for (Map.Entry<String, OnEnterRef> entry : mOnEnterCallbacks.entrySet()) {
             if (!mStates.contains(nameToStateMap.get(entry.getKey()))) {
                 isValid = false;
-                messager.printMessage(Diagnostic.Kind.ERROR, errorTag + " - Unknown STATE "
+                messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING, errorTag + " - Unknown STATE "
                         + entry.getKey() + " used in OnEnter " + entry.getValue().getConnectionName() + ". Do you have a typo?");
             }
         }
@@ -466,7 +466,7 @@ class Model {
         for (Map.Entry<String, OnEnterRef> entry : mOnEnterCallbacks.entrySet()) {
             if (!mStates.contains(nameToStateMap.get(entry.getKey()))) {
                 isValid = false;
-                messager.printMessage(Diagnostic.Kind.ERROR, errorTag + " - Unknown STATE "
+                messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING, errorTag + " - Unknown STATE "
                         + entry.getKey() + " used in OnExit " + entry.getValue().getConnectionName() + ". Do you have a typo?");
             }
         }
@@ -478,12 +478,12 @@ class Model {
         for (ConnectionRef autoConnection : allAutoConnections) {
             if (!mStates.contains(nameToStateMap.get(autoConnection.getFrom()))) {
                 isValid = false;
-                messager.printMessage(Diagnostic.Kind.ERROR, errorTag + " - Unknown from STATE "
+                messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING, errorTag + " - Unknown from STATE "
                         + autoConnection.getFrom() + " used in auto connection " + autoConnection.getName() + ". Do you have a typo?");
             }
             if (!mStates.contains(nameToStateMap.get(autoConnection.getTo()))) {
                 isValid = false;
-                messager.printMessage(Diagnostic.Kind.ERROR, errorTag + " - Unknown to STATE "
+                messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING, errorTag + " - Unknown to STATE "
                         + autoConnection.getTo() + " used in auto connection " + autoConnection.getName() + ". Do you have a typo?");
             }
         }
@@ -492,7 +492,7 @@ class Model {
 
     private boolean checkStatesDefined(String errorTag, Messager messager) {
         if (mSignalsEnumName == null || mSignalsEnumName.length() == 0) {
-            messager.printMessage(Diagnostic.Kind.ERROR, errorTag + " - Couldn't find an enum with the annotation @Signals");
+            messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING, errorTag + " - Couldn't find an enum with the annotation @Signals");
             return false;
         }
         return true;
@@ -500,7 +500,7 @@ class Model {
 
     private boolean checkSignalsDefined(String errorTag, Messager messager) {
         if (mSignalsEnumName == null || mSignalsEnumName.length() == 0) {
-            messager.printMessage(Diagnostic.Kind.ERROR, errorTag + " - Couldn't find an enum with the annotation @Signals");
+            messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING, errorTag + " - Couldn't find an enum with the annotation @Signals");
             return false;
         }
         return true;

--- a/anno-state-machine-processor/src/main/java/se/transientink/annostatemachine/processor/StateMachineProcessor.java
+++ b/anno-state-machine-processor/src/main/java/se/transientink/annostatemachine/processor/StateMachineProcessor.java
@@ -71,7 +71,9 @@ final public class StateMachineProcessor extends AbstractProcessor {
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        boolean hasStateMachineAnnotation = false;
         for (Element element : roundEnv.getElementsAnnotatedWith(StateMachine.class)) {
+            hasStateMachineAnnotation = true;
             try {
                 // Clean model for each state machine source file
                 mModel = new Model();
@@ -82,18 +84,18 @@ final public class StateMachineProcessor extends AbstractProcessor {
                     if (mModel.validateModel(element.getSimpleName().toString(), processingEnv.getMessager())) {
                         mStateMachineCreator.writeStateMachine(element, mModel, processingEnv);
                     } else {
-                        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, mModel.getSourceClassName() + ": Invalid state machine - Not generating implementation.");
+                        mStateMachineCreator.writeStateMachineStub(element, mModel, processingEnv);
                     }
                 } else {
-                    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
                             "Non class using " + StateMachine.class.getSimpleName() + " annotation");
                 }
             } catch (Throwable t) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Throwable caught when creating state machine impl for " + element.getSimpleName());
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING, "Throwable caught when creating state machine impl for " + element.getSimpleName());
                 t.printStackTrace();
             }
         }
-        return true;
+        return hasStateMachineAnnotation;
     }
 
     private void generateModel(Element element) {
@@ -139,7 +141,7 @@ final public class StateMachineProcessor extends AbstractProcessor {
     private void collectOnExit(Element element) {
         if (!(element.getKind() == ElementKind.METHOD)) {
             // OnExit annotation on something other than a method
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
                     "Non method " + element.getSimpleName() + " using annotation " + OnExit.class.getSimpleName());
             return;
         }
@@ -151,7 +153,7 @@ final public class StateMachineProcessor extends AbstractProcessor {
         try {
             mModel.add(connectionRef);
         } catch (IllegalArgumentException e) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
                     mModel.getSourceClassName() + ": " + e.getMessage());
         }
     }
@@ -159,7 +161,7 @@ final public class StateMachineProcessor extends AbstractProcessor {
     private void collectOnEnter(Element element) {
         if (!(element.getKind() == ElementKind.METHOD)) {
             // OnEnter annotation on something other than a method
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
                     "Non method " + element.getSimpleName() + " using annotation " + OnEnter.class.getSimpleName());
             return;
         }
@@ -171,7 +173,7 @@ final public class StateMachineProcessor extends AbstractProcessor {
         try {
             mModel.add(connectionRef);
         } catch (IllegalArgumentException e) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
                     mModel.getSourceClassName() + ": " + e.getMessage());
         }
     }
@@ -179,7 +181,7 @@ final public class StateMachineProcessor extends AbstractProcessor {
     private void collectStates(Element element) {
         if (!(element.getKind().equals(ElementKind.ENUM))) {
             // States annotation on something other than an enum
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
                     "Non enum " + element.getSimpleName() + " of type " + element.getKind() + " using annotation " + States.class.getSimpleName());
             return;
         }
@@ -197,7 +199,7 @@ final public class StateMachineProcessor extends AbstractProcessor {
     private void collectSignals(Element element) {
         if (!(element.getKind().equals(ElementKind.ENUM))) {
             // Signal annotation on something other than an enum
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
                     "Non enum " + element.getSimpleName() + " of type " + element.getKind() + " using annotation " + Signals.class.getSimpleName());
             return;
         }
@@ -214,7 +216,7 @@ final public class StateMachineProcessor extends AbstractProcessor {
     private void collectConnection(Element element) {
         if (!(element.getKind() == ElementKind.METHOD)) {
             // Connection annotation on something other than a method
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
                     "Non method " + element.getSimpleName() + " using annotation " + Connection.class.getSimpleName());
             return;
         }

--- a/anno-state-machine-processor/src/main/java/se/transientink/annostatemachine/processor/StateMachineStubProcessor.java
+++ b/anno-state-machine-processor/src/main/java/se/transientink/annostatemachine/processor/StateMachineStubProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Max Ringström
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.transientink.annostatemachine.processor;
+
+
+import com.jayway.annostatemachine.annotations.IncompleteStateMachine;
+import com.jayway.annostatemachine.annotations.StateMachine;
+
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+
+/**
+ * Reads state machine declaration classes with the annotation {@link StateMachine} and generates
+ * the corresponding state machine implementation classes. The implementation classes are placed
+ * in a sub package of the declaration class' package. The sub package is named "generated".
+ */
+@SupportedAnnotationTypes("com.jayway.annostatemachine.annotations.IncompleteStateMachine")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+final public class StateMachineStubProcessor extends AbstractProcessor {
+
+    public StateMachineStubProcessor() {
+        super();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (Element element : roundEnv.getElementsAnnotatedWith(IncompleteStateMachine.class)) {
+                    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                            " State machine "    + ((TypeElement) element).getQualifiedName().toString()
+                                    + " is incorrect. See warnings.");
+        }
+        return true;
+    }
+
+}

--- a/anno-state-machine-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/anno-state-machine-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,2 @@
 se.transientink.annostatemachine.processor.StateMachineProcessor
+se.transientink.annostatemachine.processor.StateMachineStubProcessor

--- a/anno-state-machine/src/main/java/com/jayway/annostatemachine/annotations/IncompleteStateMachine.java
+++ b/anno-state-machine/src/main/java/com/jayway/annostatemachine/annotations/IncompleteStateMachine.java
@@ -1,0 +1,8 @@
+package com.jayway.annostatemachine.annotations;
+
+/**
+ * The state machine that has this annotation is a stub. This tag should be placed on machines
+ * that could not be properly compiled due to client errors.
+ */
+public @interface IncompleteStateMachine {
+}


### PR DESCRIPTION
We always generate a class so that imports or method calls do not fail in
client code. We output warnings instead of errors so that we do not
get unnecessary compiler errors that clog up the log. If a state machine
is incomplete the annotation @IncompleteStateMachine is added and a separate
processor has been added for that annotation. The annotation is added by the
StateMachine annotation processor which means that the IncompleteStateMachine
annotation processor can safely fail the build.